### PR TITLE
feat(typesnob): add diagonal arrows

### DIFF
--- a/extensions/type-snob/src/characters.ts
+++ b/extensions/type-snob/src/characters.ts
@@ -366,6 +366,30 @@ const miscChars: Character[] = [
     html: "&darr;",
   },
   {
+    label: "Upper left arrow",
+    value: "↖",
+    example: "Swipe ↖ to access menu",
+    html: "&nwarr;",
+  },
+  {
+    label: "Upper right arrow",
+    value: "↗",
+    example: "Swipe ↗ to expand options",
+    html: "&nearr;",
+  },
+  {
+    label: "Lower left arrow",
+    value: "↙",
+    example: "Swipe ↙ to minimize options",
+    html: "&swarr;",
+  },
+  {
+    label: "Lower right arrow",
+    value: "↘",
+    example: "Swipe ↘ to access settings",
+    html: "&searr;",
+  },
+  {
     label: "Wavy dash",
     value: "〰",
     keywords: ["wave", "squiggle"],


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
Adds diagonal arrows to TypeSnob extension

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
